### PR TITLE
Fix line break removal before package directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/segmentio/golines
 go 1.18
 
 require (
-	github.com/dave/dst v0.27.0
+	github.com/dave/dst v0.27.3
 	github.com/dave/jennifer v1.5.0
 	github.com/fatih/structtag v1.2.0
 	github.com/golangci/golangci-lint v1.54.2

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/daixiang0/gci v0.11.0/go.mod h1:xtHP9N7AHdNvtRNfcx9gwTDfw7FRJx4bZUsiE
 github.com/dave/astrid v0.0.0-20170323122508-8c2895878b14/go.mod h1:Sth2QfxfATb/nW4EsrSi2KyJmbcniZ8TgTaji17D6ms=
 github.com/dave/brenda v1.1.0/go.mod h1:4wCUr6gSlu5/1Tk7akE5X7UorwiQ8Rij0SKH3/BGMOM=
 github.com/dave/courtney v0.3.0/go.mod h1:BAv3hA06AYfNUjfjQr+5gc6vxeBVOupLqrColj+QSD8=
-github.com/dave/dst v0.27.0 h1:vh51Zc/7bH5YfbspFsEizLuQ1xm6zDQWMJiIlZhiNQ4=
-github.com/dave/dst v0.27.0/go.mod h1:eF/UOVnw9Ech3NkZFCdtujtISJFRYf11+I93p+RI5S4=
+github.com/dave/dst v0.27.3 h1:P1HPoMza3cMEquVf9kKy8yXsFirry4zEnWOdYPOoIzY=
+github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
 github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gKdIDIxuLDFob7ustLAVqhsZRk2qVZrArELGQ=
 github.com/dave/jennifer v1.5.0 h1:HmgPN93bVDpkQyYbqhCHj5QlgvUkvEOzMyEvKLgCRrg=
 github.com/dave/jennifer v1.5.0/go.mod h1:4MnyiFIlZS3l5tSDn8VnzE6ffAhYBMB2SZntBsZGUok=

--- a/internal/testdata/doc_comment_block.go
+++ b/internal/testdata/doc_comment_block.go
@@ -1,0 +1,4 @@
+/*
+This is a long package comment. It contains nothing interesting but is longer than the default line limit
+*/
+package fixtures

--- a/internal/testdata/doc_comment_block__exp.go
+++ b/internal/testdata/doc_comment_block__exp.go
@@ -1,0 +1,4 @@
+/*
+This is a long package comment. It contains nothing interesting but is longer than the default line limit
+*/
+package fixtures


### PR DESCRIPTION
Due to an upstream bug[1] if `golines` were to reformat (i.e. it actually found a line that was too long) a file with a block comment before the package directive, the newline before the package directive would be stripped, e.g.

    /*
    this is a comment
    */
    package foo

Would become

    /*
    this is a comment
    */ package foo

The underlying issue has been fixed upstream, so fix here by bumping the version of `github.com/dave/dst` to include that fix. Here's a summary of the changes in that package from the previously used version:

    $ git log --no-merges --format='%h %s' v0.27.0..v0.27.3
    5fa8d6e Fixes #69
    bc71a76 Upgrade golang.org/x/tools to v0.1.12
    b6f3447 decorator: make an error more verbose

[1] https://github.com/dave/dst/issues/69