### PR TITLE
More post fork work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Circle CI](https://circleci.com/gh/segmentio/golines.svg?style=svg&circle-token=b1d01d8b035ef0aa71ccd183580586a80cd85271)](https://circleci.com/gh/segmentio/golines)
-[![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/golines)](https://goreportcard.com/report/github.com/segmentio/golines)
-[![GoDoc](https://godoc.org/github.com/segmentio/golines?status.svg)](https://godoc.org/github.com/segmentio/golines)
-[![Coverage](https://img.shields.io/badge/Go%20Coverage-84%25-brightgreen.svg?longCache=true&style=flat)](https://gocover.io/github.com/segmentio/golines?version=1.13.x)
+[![Pipeline
+Statues](https://github.com/matthewhughes934/golines/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/matthewhughes934/golines/actions?query=branch%3Amain)
+[![Go Report Card](https://goreportcard.com/badge/github.com/matthewhughes934/golines)](https://goreportcard.com/report/github.com/matthewhughes934/golines)
+[![GoDoc](https://godoc.org/github.com/matthewhughes934/golines?status.svg)](https://godoc.org/github.com/matthewhughes934/golines)
 
 # golines
 
@@ -60,13 +60,13 @@ release.
 First, install the tool. If you're using golang 1.18 or newer, run:
 
 ```
-go install github.com/segmentio/golines@latest
+go install github.com/matthewhughes934/golines@latest
 ```
 
 Otherwise, for older golang versions, run:
 
 ```
-go install github.com/segmentio/golines@v0.9.0
+go install github.com/matthewhughes934/golines@v0.9.0
 ```
 
 Then, run:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/golines
+module github.com/matthewhughes934/golines
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"runtime/pprof"
 	"strings"
 
-	"github.com/segmentio/golines/internal"
+	"github.com/matthewhughes934/golines/internal"
 	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"

--- a/scripts/generate/doc.go
+++ b/scripts/generate/doc.go
@@ -1,4 +1,4 @@
 /*
 Command generate is used to generate code that creates dot files from golang ASTs.
 */
-package main // import "github.com/segmentio/golines/generate"
+package main


### PR DESCRIPTION
- Update README badges and links

    * Replace `CircleCI` badge with GitHub action one
    * Drop `coverage` badge since nothing is measuring or reporting this at
      the moment
    * Update godoc link

- Update module path to reflect fork

    I didn't see much value in the import comment[1] so that was removed

    [1] https://pkg.go.dev/cmd/go#hdr-Import_path_checking