### PR TITLE
Some updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - revive
     - misspell
     - nakedret
-    - gas
+    - gosec
     - unconvert
     - unparam
     - prealloc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.0
+    rev: v1.61.0
     hooks:
     -   id: golangci-lint-full
 -   repo: .
@@ -9,7 +9,7 @@ repos:
     -   id: golines
         exclude: internal/testdata
 -   repo: https://gitlab.com/matthewhughes/go-pre-commit
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
     -   id: go-mod-tidy
 -   repo: https://gitlab.com/matthewhughes/common-changelog

--- a/internal/shortener_test.go
+++ b/internal/shortener_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,7 +24,7 @@ func init() {
 // directory. To update the expected outputs, run tests with the REGENERATE_TEST_OUTPUTS
 // environment variable set to "true".
 func TestShortener(t *testing.T) {
-	info, err := ioutil.ReadDir(testdataDir)
+	info, err := os.ReadDir(testdataDir)
 	assert.Nil(t, err)
 
 	fixturePaths := []string{}
@@ -45,7 +44,7 @@ func TestShortener(t *testing.T) {
 		)
 	}
 
-	dotDir, err := ioutil.TempDir("", "dot")
+	dotDir, err := os.MkdirTemp("", "dot")
 	if err != nil {
 		t.Fatalf("Error creating output directory for dot files: %+v", err)
 	}
@@ -66,7 +65,7 @@ func TestShortener(t *testing.T) {
 	)
 
 	for _, fixturePath := range fixturePaths {
-		contents, err := ioutil.ReadFile(fixturePath)
+		contents, err := os.ReadFile(fixturePath)
 		if err != nil {
 			t.Fatalf(
 				"Unexpected error reading fixture %s: %+v",
@@ -81,7 +80,7 @@ func TestShortener(t *testing.T) {
 		expectedPath := fixturePath[0:len(fixturePath)-3] + "__exp" + ".go"
 
 		if os.Getenv("REGENERATE_TEST_OUTPUTS") == "true" {
-			err := ioutil.WriteFile(expectedPath, shortenedContents, 0o600)
+			err := os.WriteFile(expectedPath, shortenedContents, 0o600)
 			if err != nil {
 				t.Fatalf(
 					"Unexpected error writing output file %s: %+v",
@@ -91,7 +90,7 @@ func TestShortener(t *testing.T) {
 			}
 		}
 
-		expectedContents, err := ioutil.ReadFile(expectedPath)
+		expectedContents, err := os.ReadFile(expectedPath)
 		if err != nil {
 			t.Fatalf(
 				"Unexpected error reading expected file %s: %+v",

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -124,7 +124,7 @@ func run() error {
 
 	if len(*paths) == 0 {
 		// Read input from stdin
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func processFile(shortener *internal.Shortener, path string) ([]byte, []byte, er
 
 	log.Debugf("Processing file %s", path)
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -245,7 +245,7 @@ func handleOutput(path string, contents []byte, result []byte) error {
 			return nil
 		} else {
 			log.Debugf("Contents changed, writing output to %s", path)
-			return ioutil.WriteFile(path, result, info.Mode())
+			return os.WriteFile(path, result, info.Mode())
 		}
 	} else {
 		fmt.Print(string(result))

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,7 +27,7 @@ func main() {
 }
 
 func TestRunDir(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "go")
+	tmpDir, err := os.MkdirTemp("", "go")
 	if err != nil {
 		t.Fatal("Unexpected error creating temp dir", err)
 	}
@@ -45,7 +45,7 @@ func TestRunDir(t *testing.T) {
 	// Without writeOutput set to true, inputs should be unchanged
 	for name, contents := range testFiles {
 		path := filepath.Join(tmpDir, name)
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal("Unexpected error reading test file", err)
 		}
@@ -65,7 +65,7 @@ func TestRunDir(t *testing.T) {
 	for name, contents := range testFiles {
 		path := filepath.Join(tmpDir, name)
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal("Unexpected error reading test file", err)
 		}
@@ -79,7 +79,7 @@ func TestRunDir(t *testing.T) {
 }
 
 func TestRunFilePaths(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "go")
+	tmpDir, err := os.MkdirTemp("", "go")
 	if err != nil {
 		t.Fatal("Unexpected error creating temp dir", err)
 	}
@@ -98,7 +98,7 @@ func TestRunFilePaths(t *testing.T) {
 	for name, contents := range testFiles {
 		path := filepath.Join(tmpDir, name)
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal("Unexpected error reading test file", err)
 		}
@@ -112,7 +112,7 @@ func TestRunFilePaths(t *testing.T) {
 }
 
 func TestRunListFiles(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "go")
+	tmpDir, err := os.MkdirTemp("", "go")
 	if err != nil {
 		t.Fatal("Unexpected error creating temp dir", err)
 	}
@@ -170,7 +170,7 @@ func writeTestFiles(
 			paths = &tmpPaths
 		}
 
-		err := ioutil.WriteFile(path, []byte(contents), 0o600)
+		err := os.WriteFile(path, []byte(contents), 0o600)
 		if err != nil {
 			t.Fatal("Unexpected error writing test file", err)
 		}
@@ -192,7 +192,7 @@ func captureStdout(t *testing.T, f func() error) (string, error) {
 	resultErr := f()
 
 	w.Close()
-	outBytes, err := ioutil.ReadAll(r)
+	outBytes, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal("Unexpected error reading result", err)
 	}


### PR DESCRIPTION
- Add `dependabot` config

- Update `pre-commit`

    I.e. `pre-commit autoupdate`. This updated `golangci-lint` which
    raised some new issues relating to:

        SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details.

    There was also a deprecation warning:

        WARN [lintersdb] The name "gas" is deprecated. The linter has been renamed to: gosec.

    That was addressed by updating the linter name